### PR TITLE
using the 2nd callback when the first is undefined

### DIFF
--- a/runtime-shim.js
+++ b/runtime-shim.js
@@ -1,7 +1,7 @@
 module.exports = function(nunjucks, env, obj, dependencies){
 
     var oldRoot = obj.root;
-    obj.root = function( env, context, frame, runtime, cb ) {
+    obj.root = function( env, context, frame, runtime, cb, cb2 ) {
         var oldGetTemplate = env.getTemplate;
         env.getTemplate = function( name, ec, cb ) {
             if( typeof ec === "function" ) {
@@ -21,6 +21,7 @@ module.exports = function(nunjucks, env, obj, dependencies){
             var tmpl = _require( name );
             frame.set( "_require", _require );
             if( ec ) tmpl.compile();
+            if(! cb ) cb = cb2;
             cb( null, tmpl );
         };
 


### PR DESCRIPTION
I am not a clever man, i don't know why sometimes `cb` is undefined.
I tried to extend a template and it utterly failed with: 

    Uncaught Template render error: (unknown path)
      TypeError: cb is not a function

Looking at the source that is generated bynunjucks, it IS passing an `undefined`, but the forth arg is an actual callback and using that callback actually worked.