### PR TITLE
Fixed error resolving path to nunjucks.config.js in Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ module.exports = function(source) {
     compiledTemplate += 'var dependencies = {};\n';
 
     if( pathToConfigure ){
-        compiledTemplate += 'var configure = require("' + pathToConfigure + '")(env);\n';
+        compiledTemplate += 'var configure = require("' + slash(pathToConfigure) + '")(env);\n';
     }
 
     while( match = reg.exec( nunjucksCompiledStr ) ) {


### PR DESCRIPTION
When using config.query querystring like in Adding custom filters and extensions documentation section (`'config': __dirname + '/src/nunjucks.config.js'`) it causes Webpack error in Windows: `Can't find module named "pathwithoutslashestosrcnunjucks.config.js"`.
Fixed in this commit.