### PR TITLE
Switched to loader-utils for query params parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@
 var nunjucks = require('nunjucks');
 var slash = require('slash');
 var path = require('path');
+var loaderUtils = require('loader-utils');
 var env = new nunjucks.Environment([]);
 var hasRun = false;
 var pathToConfigure;
@@ -23,18 +24,17 @@ module.exports = function (source) {
     this.cacheable();
 
     if (!hasRun){
-        var query = this.query.replace('?', '');
-        if (query.length > 0){
-            var q = JSON.parse(query);
-            if(q.config){
-                pathToConfigure = q.config;
+        var query = loaderUtils.parseQuery(this.query);
+        if (query){
+            if(query.config){
+                pathToConfigure = query.config;
                 try {
-                    var configure = require(q.config);
+                    var configure = require(query.config);
                     configure(env);
                 }
                 catch (e) {
                     if (e.code === 'MODULE_NOT_FOUND') {
-                        if (!q.quiet) {
+                        if (!query.quiet) {
                             var message = 'Cannot configure nunjucks environment before precompile\n' +
                                     '\t' + e.message + '\n' +
                                     'Async filters and custom extensions are unsupported when the nunjucks\n' +
@@ -53,8 +53,8 @@ module.exports = function (source) {
 
             // Specify the template search path, so we know from what directory
             // it should be relative to.
-            if (q.root) {
-                root = q.root;
+            if (query.root) {
+                root = query.root;
             }
         }
         hasRun = true;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/at0g/nunjucks-loader",
   "dependencies": {
+    "loader-utils": "^0.2.12",
     "slash": "~1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Hi! Faced a problem, when i need to use more than 1 loader for processing, in that case we can not use object-style for loader config, and need to specify all loaders params in query string. There was a bug in that case. Now it's fixed! ;)