### PR TITLE
Add support for experimental Jinja compatibility features

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ var loaderUtils = require('loader-utils');
 var env = new nunjucks.Environment([]);
 var hasRun = false;
 var pathToConfigure;
+var jinjaCompatStr;
 var root;
 
 module.exports = function (source) {
@@ -56,6 +57,11 @@ module.exports = function (source) {
             if (query.root) {
                 root = query.root;
             }
+
+            // Enable experimental Jinja compatibility to be enabled
+            if(query.jinjaCompat){
+                jinjaCompatStr = 'nunjucks.installJinjaCompat();\n';
+            }
         }
         hasRun = true;
     }
@@ -80,6 +86,9 @@ module.exports = function (source) {
     // ================================================================
     var compiledTemplate = '';
     compiledTemplate += 'var nunjucks = require("exports?nunjucks!nunjucks/browser/nunjucks-slim");\n';
+    if (jinjaCompatStr) {
+        compiledTemplate += jinjaCompatStr + '\n';
+    }
     compiledTemplate += 'var env;\n';
     compiledTemplate += 'if (!nunjucks.currentEnv){\n';
     compiledTemplate += '\tenv = nunjucks.currentEnv = new nunjucks.Environment([], { autoescape: true });\n';

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@
 - resolves template dependencies using `require`
 - bundles the nunjucks-slim browser runtime
 - use the version of nunjucks you want to as a peer dependency
+- supports experimental Jinja compatibility
 
 ## Usage
 
@@ -194,6 +195,37 @@ module.exports = {
     }
 }
 ```
+
+
+## Jinja/Python compatibility
+
+If [experimental support for Jinja compatibility](https://mozilla.github.io/nunjucks/api.html#installjinjacompat)
+is desired, pass the jinjaCompat option in the loader query. eg:
+
+```
+// file: webpack.config.js
+module.exports = {
+
+    module: {
+        loaders: [
+            {
+                test: /\.(nunj|nunjucks)$/,
+                loader: 'nunjucks-loader',
+                query: {
+                    jinjaCompat: true
+                }
+            }
+        ]
+    }
+};
+```
+
+This option will not provide full Jinja/Python compatibility, but will treat `True`/`False` like `true`/`false`, and
+augment arrays and objects with Python-style methods (such as `count`, `find`, `insert`, `get`, and `update`).
+Review the [jinja-compat source](https://github.com/mozilla/nunjucks/blob/master/src/jinja-compat.js) to see
+everything it adds.
+
+
 
 
 ## Tests

--- a/test/fixtures/lib.js
+++ b/test/fixtures/lib.js
@@ -4,4 +4,5 @@ exports['include-basic.nunj'] = require('include-basic.nunj');
 exports['include-within-block.nunj'] = require('include-within-block.nunj');
 exports['global-value.nunj'] = require('global-value.nunj');
 exports['standard-filter.nunj'] = require('standard-filter.nunj');
+exports['jinja-compat.nunj'] = require('jinja-compat.nunj');
 exports['require.nunj'] = require('require.nunj');

--- a/test/fixtures/templates/jinja-compat.nunj
+++ b/test/fixtures/templates/jinja-compat.nunj
@@ -1,0 +1,1 @@
+{{ myObject.get('myProp', 'notfound') }}

--- a/test/spec/environment.js
+++ b/test/spec/environment.js
@@ -1,5 +1,6 @@
 var globalValue = require('global-value.nunj');
 var standardFilter = require('standard-filter.nunj');
+var jinjaCompat = require('jinja-compat.nunj');
 
 describe('nunjucks environment', function () {
 
@@ -22,6 +23,28 @@ describe('nunjucks environment', function () {
             standardFilter.render({number: 20}, function (err, result) {
                 should.not.exist(err);
                 result.should.equal('40');
+                done();
+            });
+        });
+
+    });
+
+    describe('jinja compat', function () {
+
+        it('should render a property value', function (done) {
+            jinjaCompat.render({myObject: {myProp: 'foo'}}).should.equal('foo');
+            jinjaCompat.render({myObject: {myProp: 'bar'}}, function (err, result) {
+                should.not.exist(err);
+                result.should.equal('bar');
+                done();
+            });
+        });
+
+        it('should render a default property value', function (done) {
+            jinjaCompat.render().should.equal('notfound');
+            jinjaCompat.render(null, function (err, result) {
+                should.not.exist(err);
+                result.should.equal('notfound');
                 done();
             });
         });

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
                 test: /\.(nunj|nunjucks)$/,
                 loader: 'index',
                 query: {
+                    jinjaCompat: true,
                     config: __dirname + '/nunjucks.config.js'
                 }
             },


### PR DESCRIPTION
- Added `jinjaCompat` config option to enable the [installJinjaCompat](https://mozilla.github.io/nunjucks/api.html#installjinjacompat) function to be called on the runtime instance of nunjucks
- Updated unit tests and README