### PR TITLE
Fixed error resolving path to config in Windows again

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ module.exports = function (source) {
     compiledTemplate += '\tenv = nunjucks.currentEnv;\n';
     compiledTemplate += '}\n';
     if (pathToConfigure) {
-        compiledTemplate += 'var configure = require("' + path.relative(this.context, slash(pathToConfigure)) + '")(env);\n';
+        compiledTemplate += 'var configure = require("' + slash(path.relative(this.context, pathToConfigure)) + '")(env);\n';
     }
 
 


### PR DESCRIPTION
Each path returned by some methods of `path` module needs to be processed by `slash` module before inlining in compiled template on Windows.