### PR TITLE
Require nunjucks w/o exports loader (as of nj2.5.0)

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ module.exports = function (source) {
     // Begin to write the compiled template output to return to webpack
     // ================================================================
     var compiledTemplate = '';
-    compiledTemplate += 'var nunjucks = require("exports?nunjucks!nunjucks/browser/nunjucks-slim");\n';
+    compiledTemplate += 'var nunjucks = require("nunjucks/browser/nunjucks-slim");\n';
     if (jinjaCompatStr) {
         compiledTemplate += jinjaCompatStr + '\n';
     }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "slash": "~1.0.0"
   },
   "peerDependencies": {
-    "nunjucks": "^2.0.0",
+    "nunjucks": "^2.5.0",
     "exports-loader": "^0.6.2"
   },
   "devDependencies": {
@@ -36,7 +36,7 @@
     "exports-loader": "^0.6.2",
     "mocha": "^2.2.1",
     "mocha-loader": "^0.7.1",
-    "nunjucks": "^2.2.0",
+    "nunjucks": "^2.5.0",
     "raw-loader": "^0.5.1"
   }
 }

--- a/test/spec/nunjucks-loader.js
+++ b/test/spec/nunjucks-loader.js
@@ -1,4 +1,4 @@
-var nunjucks = require("exports?nunjucks!nunjucks/browser/nunjucks-slim");
+var nunjucks = require("nunjucks/browser/nunjucks-slim");
 
 var templateOne = require('hero/default.njk');
 var templateTwo = require('villain/default.njk');


### PR DESCRIPTION
As of nunjucks 2.5.0, the browser files are being built with `webpackUniversalModuleDefinition` rather than exposing a global `nunjucks` variable. Therefore, requiring nunjucks (in index.js) with the exports loader was resulting in the error: `Uncaught ReferenceError: nunjucks is not defined`. Removing the `exports?nunjucks!` part from the require argument allows it to load properly again. 

Your tests confirmed that it was breaking when nunjucks 2.5.x was installed, and making the changes in this PR allowed the tests to pass.

This should fix gh-36.