### PR TITLE
fix compatibility issue with webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function (source) {
         hasRun = true;
     }
 
-    var name = slash(path.relative(root || this.rootContext, this.resourcePath));
+    var name = slash(path.relative(root || this.rootContext || this.options.context, this.resourcePath));
 
     var nunjucksCompiledStr = nunjucks.precompileString(source, {
             env: env,

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function (source) {
         hasRun = true;
     }
 
-    var name = slash(path.relative(root || this.options.context, this.resourcePath));
+    var name = slash(path.relative(root || this.rootContext, this.resourcePath));
 
     var nunjucksCompiledStr = nunjucks.precompileString(source, {
             env: env,


### PR DESCRIPTION
`this.option.context` has been deprecated since webpack 3, it's been
replaced by `this.rootContext` in webpack 4.

I haven't tested everything, this is just a really quick fix I did to make my webpack 4 compile.
I also don't know if this fix is backwards compatible.

however, this was the only instance of `this.options.context` in the code, so I doubt it will break anything.

See #61