### PR TITLE
Use getOptions instead of parseQuery

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function (source) {
     this.cacheable();
 
     if (!hasRun){
-        var query = loaderUtils.parseQuery(this.query);
+        var query = loaderUtils.getOptions(this);
         var envOpts = query.opts || {};
         if (query){
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/at0g/nunjucks-loader",
   "dependencies": {
-    "loader-utils": "^0.2.12",
+    "loader-utils": "^1.1.0",
     "slash": "~1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR introduces changes already made in #48, but they were revereted, probably because loader-utils `getOptions` method should parse `this` instead of `this.query`. All tests are passing!

It also relates to #55.